### PR TITLE
ci: add auto-build workflow for frontend dist

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -1,0 +1,50 @@
+name: Build Frontend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "streamlit_advanced_dataframe/frontend/**"
+      - "!streamlit_advanced_dataframe/frontend/dist/**"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: streamlit_advanced_dataframe/frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: streamlit_advanced_dataframe/frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add dist/
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "build: update frontend dist
+
+          🤖 Generated with GitHub Actions"
+            git push
+          fi
+        working-directory: ${{ github.workspace }}


### PR DESCRIPTION
## Summary
- mainブランチへのpush時に`frontend/dist`を自動ビルド・コミットするワークフローを追加
- `frontend/`配下の変更時のみトリガー（`dist/`は除外で無限ループ防止）
- Node.js 20で`npm run build`を実行し、変更がある場合のみgithub-actions[bot]としてコミット

## Test plan
- [ ] PRマージ後、frontend/配下のファイル変更を含むコミットをpushしてワークフローが実行されることを確認
- [ ] ビルド成果物が自動的にコミットされることを確認
- [ ] dist/のみの変更では再トリガーされないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)